### PR TITLE
Ensure 'proxies' is initialized

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -138,6 +138,10 @@ with open("sites.yaml", "r", encoding="utf-8") as f:
 with open(sys.argv[1], "r", encoding="utf-8") as f:
     config = yaml.load(f, Loader=FullLoader)
 
+# Ensure 'proxies' is initialized
+if 'proxies' not in config or config['proxies'] is None:
+    config['proxies'] = []
+
 for site in sites:
     if site.data != None:
         try:


### PR DESCRIPTION
当 template.yaml 中 proxies 为空时，初始化 config['proxies'] 。